### PR TITLE
nicer clickable paths in source_locations

### DIFF
--- a/lib/where_is.rb
+++ b/lib/where_is.rb
@@ -80,7 +80,15 @@ module Where
     private
 
     def source_location(method)
-      method.source_location || method.to_s[/: (.*)>/, 1]
+      source_location = method.source_location
+      return method.to_s[/: (.*)>/, 1] if source_location.nil?
+
+       # source_location is a 2 element array
+       # [filename, line_number]
+       # some terminals (eg. iterm) will jump to the file if you cmd+click it
+       # but they can jump to the specific line if you concat file & line number!
+       filename, line = source_location
+       {file: filename, line: line, path: "#{filename}:#{line}"}
     end
 
     def group_and_combine_source_locations(source_locations)


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/509837/37072770-d936dbe0-220e-11e8-886a-7ab41ebba8f7.png)

after:

![image](https://user-images.githubusercontent.com/509837/37072775-dfc63da2-220e-11e8-96ed-683a28975b78.png)

this is much handier on very long files since if your terminal is cool it will jump to the correct line.